### PR TITLE
DKP-2859 start: bound docker readiness wait and dump logs on timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ Note that the usage of Docker Desktop is subject to [Docker Desktop license agre
 
 After this step executes, Docker Desktop is ready and available, the docker CLI can be executed in subsequent "run" steps
 
+## Choosing a runner
+
+Docker Desktop runs a Linux VM, so the runner needs enough CPU and memory or
+`dockerd` can fail to finish starting and the action hangs waiting on the daemon.
+At least 4 vCPUs and 16 GB of RAM is a good baseline.
+
+Watch out for `ubuntu-latest`: GitHub gives public repositories a 4 vCPU / 16 GB
+runner, but private and internal repositories get a smaller 2 vCPU / 7 GB one,
+and on that box `dockerd` often stalls during startup and never becomes ready.
+If your repository is private or internal, pick a larger runner (e.g. a
+[GitHub larger runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners)
+with 4 vCPUs / 16 GB), not plain `ubuntu-latest`.
+
 By default, the action downloads the last version of Docker Desktop. But you can specify another one by providing the build URL from where the action can download the specific version:
 
 ```

--- a/start/action.yml
+++ b/start/action.yml
@@ -147,6 +147,18 @@ runs:
     - name: Wait for Docker to be up and running
       shell: bash
       run: |
-        until docker ps; do echo "docker not ready, sleep 10 s and try again"; sleep 10; done
+        deadline=$(( $(date +%s) + 600 ))
+        until timeout 60 docker ps >/dev/null 2>&1; do
+          if (( $(date +%s) >= deadline )); then
+            echo "::error::Docker did not become ready within 600s"
+            echo "----- host logs (incl. backend) -----"
+            cat ~/.docker/desktop/log/host/*.log 2>/dev/null || true
+            echo "----- vm logs (console) -----"
+            cat ~/.docker/desktop/log/vm/*.log 2>/dev/null || true
+            exit 1
+          fi
+          echo "docker not ready, sleep 10 s and try again"
+          sleep 10
+        done
         echo "Docker started and ready"
         docker version


### PR DESCRIPTION
Closes #3.

### What this PR does

Bounds the "wait for Docker" loop so a daemon that never comes up fails fast instead of hanging until the job is cancelled, and documents the runner sizing that avoids the hang in the first place.

### Notes for the reviewer

The loop ran `until docker ps`. Turns out when the daemon is wedged that call blocks forever rather than returning non-zero, so the loop never iterates and we never sleep, never retry, never give up. The step just sits there until the job timeout kills it (~34 min in [this run](https://github.com/docker/desktop-cli/actions/runs/27187834540/job/80260704551)). You can tell because "docker not ready…" is never printed once.

So each `docker ps` now runs under `timeout 60`, which lets a hung daemon return and the loop give up at a 600s deadline. On timeout I dump the desktop logs so a failed start leaves a trace instead of nothing.

A step/action-level timeout isn't supported for composite actions (see the discussion in #3), hence doing it inside the loop. And the per-call `timeout 60` matters: an outer deadline check alone wouldn't fire, since `docker ps` itself blocks on a wedged daemon.

Paths checked against the pinata `paths` package on Linux:
- `~/.docker/desktop/log/host/` holds the backend log (the monitor tees the backend output to `host/monitor.log`).
- `~/.docker/desktop/log/vm/` holds the VM console (`console.log`, written straight to file by the qemu engine), which is really the one that'll tell us why the VM didn't come up.

While debugging a hang with this, the console showed the VM and containerd starting fine but `dockerd` stalling at startup on a small 2 vCPU / 7 GB runner. So I also added a "Choosing a runner" section to the README recommending 4 vCPU / 16 GB, and calling out that `ubuntu-latest` is smaller on private/internal repos.

This makes the failure visible and fast, it doesn't fix whatever is keeping the VM from booting (looks like nested KVM on the runner, but that's another story).
