### PR TITLE
start: drop space in "sleep 10 s" for consistency

### DIFF
--- a/start/action.yml
+++ b/start/action.yml
@@ -157,7 +157,7 @@ runs:
             cat ~/.docker/desktop/log/vm/*.log 2>/dev/null || true
             exit 1
           fi
-          echo "docker not ready, sleep 10 s and try again"
+          echo "docker not ready, sleep 10s and try again"
           sleep 10
         done
         echo "Docker started and ready"


### PR DESCRIPTION
Closes #37.

### What this PR does

Drops the space in `sleep 10 s` so the wait-loop messages are consistent: `within 600s` and `sleep 10s` now use the same `Ns` style.

### Notes for the reviewer

Pure wording, no behaviour change. Follow-up to the nit in #36.
